### PR TITLE
Add qemu agent script and simplify packer build

### DIFF
--- a/cloud_image.pkr.hcl
+++ b/cloud_image.pkr.hcl
@@ -8,66 +8,54 @@ packer {
 }
 
 variable "accelerator" {
-  type = string
-  default = "none"
+  type        = string
+  default     = "none"
   description = "QEMU accelerator"
 }
 
 variable "output_dir" {
-  type = string
-  default = "output"
+  type        = string
+  default     = "output"
   description = "Output directory"
 }
 
 variable "file_name" {
-  type = string
-  default = "cloud_image_x86_64_jammy"
+  type        = string
+  default     = "cloud_image_x86_64_jammy"
   description = "File name"
 }
 
 source "qemu" "ubuntu" {
-  accelerator = var.accelerator
-  cd_files = ["./cloud_init/*"]
-  cd_label = "cidata"
+  accelerator      = var.accelerator
+  cd_files         = ["./cloud_init/*"]
+  cd_label         = "cidata"
   disk_compression = true
-  disk_image = true
-  disk_size = "10G"
-  headless = true
-  iso_checksum = "file:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"
-  iso_url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  disk_image       = true
+  disk_size        = "10G"
+  headless         = true
+  iso_checksum     = "file:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"
+  iso_url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
   output_directory = var.output_dir
   qemuargs = [
     ["-m", "2048M"],
     ["-smp", "2"],
     ["-serial", "mon:stdio"]
   ]
-  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  shutdown_command   = "echo 'packer' | sudo -S shutdown -P now"
   ssh_private_key_file = "./.ssh/id_rsa"
-  ssh_username = "ubuntu"
-  vm_name = "${var.file_name}.img"
+  ssh_username       = "ubuntu"
+  vm_name            = "${var.file_name}.img"
 }
 
 build {
   sources = ["source.qemu.ubuntu"]
 
-  # provisioner "file" {
-  #   source      = "./file/node_exporter.service"
-  #   destination = "/tmp/node_exporter.service"
-  # }
-
-  # provisioner "file" {
-  #   source      = "./file/sshd_config"
-  #   destination = "/tmp/sshd_config"
-  # }
-
   provisioner "shell" {
-    execute_command = "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
+    execute_command  = "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
     environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
     scripts = [
       "./script/cloud_init.sh",
-      # "./script/sshd.sh",
-      "./script/apt.sh",
-      "./script/docker.sh",
+      "./script/qemu_agent.sh",
       "./script/cleanup.sh"
     ]
   }

--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -1,40 +1,40 @@
-#!/bin/bash -eu
+#!/bin/bash -euo pipefail
 
 echo "[INFO] Starting system cleanup"
 
 echo "[INFO] Removing SSH keys used for building"
-rm -f /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys || echo "[ERROR] Failed to remove SSH keys"
+rm -f /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys
 
 echo "[INFO] Clearing out machine ID"
-truncate -s 0 /etc/machine-id || echo "[ERROR] Failed to clear machine ID"
+truncate -s 0 /etc/machine-id
 
 echo "[INFO] Removing contents of /tmp and /var/tmp"
-rm -rf /tmp/* /var/tmp/* || echo "[ERROR] Failed to remove temporary files"
+rm -rf /tmp/* /var/tmp/*
 
 echo "[INFO] Truncating logs that have built up during the install"
-find /var/log -type f -exec truncate --size=0 {} \; || echo "[ERROR] Failed to truncate logs"
+find /var/log -type f -exec truncate --size=0 {} \;
 
 echo "[INFO] Cleaning up bash history"
-rm -f /root/.bash_history /home/ubuntu/.bash_history || echo "[ERROR] Failed to clean up bash history"
+rm -f /root/.bash_history /home/ubuntu/.bash_history
 
 echo "[INFO] Removing /usr/share/doc contents"
-rm -rf /usr/share/doc/* || echo "[ERROR] Failed to remove /usr/share/doc contents"
+rm -rf /usr/share/doc/*
 
 echo "[INFO] Removing /var/cache contents"
-find /var/cache -type f -exec rm -rf {} \; || echo "[ERROR] Failed to remove /var/cache contents"
+find /var/cache -type f -exec rm -rf {} \;
 
 echo "[INFO] Cleaning up apt cache"
-sudo apt-get -y autoremove || echo "[ERROR] Failed to autoremove apt packages"
-sudo apt-get clean || echo "[ERROR] Failed to clean apt cache."
-sudo rm -rf /var/lib/apt/lists/* || echo "[ERROR] Failed to remove apt lists"
+sudo apt-get -y autoremove
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/*
 
 echo "[INFO] Forcing a new random seed to be generated"
-rm -f /var/lib/systemd/random-seed || echo "[ERROR] Failed to remove random seed"
+rm -f /var/lib/systemd/random-seed
 
 echo "[INFO] Clearing wget history"
-rm -f /root/.wget-hsts || echo "[ERROR] Failed to clear wget history"
+rm -f /root/.wget-hsts
 
 echo "[INFO] Clearing bash history environment variable"
 export HISTSIZE=0
-
 echo "[INFO] System cleanup completed successfully!"
+

--- a/script/qemu_agent.sh
+++ b/script/qemu_agent.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -euo pipefail
+
+echo "[INFO] Installing qemu-guest-agent"
+sudo apt-get update -qq
+sudo apt-get install -y -qq qemu-guest-agent
+
+echo "[INFO] Enabling qemu-guest-agent service"
+sudo systemctl enable qemu-guest-agent
+sudo systemctl start qemu-guest-agent
+
+echo "[INFO] qemu-guest-agent installation complete!"


### PR DESCRIPTION
## Summary
- reduce the packer build to only run cloud_init, qemu_agent and cleanup
- make cleanup script fail on errors
- add a dedicated qemu_agent.sh installer

## Testing
- `bash -n script/qemu_agent.sh`
- `bash -n script/cloud_init.sh`
- `bash -n script/cleanup.sh`
- `packer validate cloud_image.pkr.hcl` *(fails: packer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686414e9a0a8832cb7a0dcc611f657f6