### PR TITLE
Trigger build after tagging

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: self-hosted
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,3 +42,12 @@ jobs:
           git config user.email "github-actions@github.com"
           git tag "${{ steps.bump.outputs.new_tag }}"
           git push origin "${{ steps.bump.outputs.new_tag }}"
+
+      - name: Trigger image build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build_release.yml \
+            --ref main \
+            -f version="${{ steps.bump.outputs.new_tag }}" \
+            -f file_name="cloud-image-x86-64-jammy"


### PR DESCRIPTION
## Summary
- ensure build job is triggered right after a new tag is created
- grant `actions: write` permission to dispatch the workflow

## Testing
- `packer validate cloud_image.pkr.hcl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865629a6168832cbb91ec596d9cb7d1