### PR TITLE
Ensure cloud-init reruns on next boot

### DIFF
--- a/cloud_image.pkr.hcl
+++ b/cloud_image.pkr.hcl
@@ -41,7 +41,7 @@ source "qemu" "ubuntu" {
     ["-smp", "2"],
     ["-serial", "mon:stdio"]
   ]
-  shutdown_command   = "echo 'packer' | sudo -S shutdown -P now"
+  shutdown_command   = "echo 'packer' | sudo -S sh -c 'rm -rf /var/lib/cloud && cloud-init clean && shutdown -P now'"
   ssh_private_key_file = "./.ssh/id_rsa"
   ssh_username       = "ubuntu"
   vm_name            = "${var.file_name}.img"

--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -36,5 +36,9 @@ rm -f /root/.wget-hsts
 
 echo "[INFO] Clearing bash history environment variable"
 export HISTSIZE=0
+
+echo "[INFO] Removing Cloud-Init state"
+rm -rf /var/lib/cloud
+cloud-init clean
 echo "[INFO] System cleanup completed successfully!"
 


### PR DESCRIPTION
## Summary
- wipe cloud-init state in `cleanup.sh`
- run cloud-init clean in shutdown command

## Testing
- `packer init cloud_image.pkr.hcl`
- `packer validate cloud_image.pkr.hcl`

------
https://chatgpt.com/codex/tasks/task_e_686585f41630832c845c60f4ce3ce764