### PR TITLE
Fix multi-line output when uploading image

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -96,7 +96,7 @@ jobs:
           response=$(curl -s -H "CLOUD-REPOSITORY-APIKEY: ${{ secrets.CLOUD_REPOSITORY_APIKEY }}" \
                        -F "file=@output/${{ env.FILE_NAME }}.img" \
                        ${{ env.CLOUD_REPOSITORY_URL }}/upload)
-          echo "response=$response" >> "$GITHUB_OUTPUT"
+          printf 'response<<EOF\n%s\nEOF\n' "$response" >> "$GITHUB_OUTPUT"
 
       - name: Parse upload response
         id: parse_response


### PR DESCRIPTION
## Summary
- fix quoting for output of upload step in build workflow

## Testing
- `packer init cloud_image.pkr.hcl`
- `packer validate cloud_image.pkr.hcl`

------
https://chatgpt.com/codex/tasks/task_e_687d4bcb8228832c8aa88042df97b069