### PR TITLE
Add upload progress script

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -92,10 +92,10 @@ jobs:
 
       - name: Upload image to cloud repository
         id: upload_img
+        env:
+          CLOUD_REPOSITORY_APIKEY: ${{ secrets.CLOUD_REPOSITORY_APIKEY }}
         run: |
-          response=$(curl -s -H "CLOUD-REPOSITORY-APIKEY: ${{ secrets.CLOUD_REPOSITORY_APIKEY }}" \
-                       -F "file=@output/${{ env.FILE_NAME }}.img" \
-                       ${{ env.CLOUD_REPOSITORY_URL }}/upload)
+          response=$(./script/upload_image.sh "output/${{ env.FILE_NAME }}.img" "${{ env.CLOUD_REPOSITORY_URL }}/upload")
           printf 'response<<EOF\n%s\nEOF\n' "$response" >> "$GITHUB_OUTPUT"
 
       - name: Parse upload response

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,2 +1,6 @@
 # cloud-image
 Custom cloud image
+
+## Upload helper script
+
+`script/upload_image.sh` uploads the built image to the configured cloud repository and shows a progress bar during the upload. The script requires `CLOUD_REPOSITORY_APIKEY` to be set and accepts the image path and optional destination URL.

--- a/script/upload_image.sh
+++ b/script/upload_image.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+
+FILE="$1"
+DEST="${2:-$CLOUD_REPOSITORY_URL/upload}"
+
+if [[ -z "$FILE" || ! -f "$FILE" ]]; then
+  echo "[ERROR] File not found: $FILE" >&2
+  exit 1
+fi
+
+if [[ -z "${CLOUD_REPOSITORY_APIKEY:-}" ]]; then
+  echo "[ERROR] CLOUD_REPOSITORY_APIKEY environment variable not set" >&2
+  exit 1
+fi
+
+echo "[INFO] Uploading '${FILE}' → ${DEST}"
+
+response="$(curl -# -S -H "CLOUD-REPOSITORY-APIKEY: ${CLOUD_REPOSITORY_APIKEY}" \
+    -F "file=@${FILE}" \
+    -w "\n%{http_code}" \
+    "${DEST}" 2>&1)" || {
+  echo "[ERROR] curl invocation failed" >&2
+  exit 1
+}
+
+http_code="${response##*$'\n'}"
+body="${response%$'\n'*}"
+
+echo "$body"
+
+if [[ "$http_code" =~ ^2 ]]; then
+  echo "[INFO] Upload succeeded (HTTP ${http_code})"
+  exit 0
+else
+  echo "[ERROR] Upload failed (HTTP ${http_code})" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `script/upload_image.sh` helper script for uploading images with progress
- use the new helper in the release workflow
- document the helper script

## Testing
- `shellcheck script/upload_image.sh`
- `bash -n script/upload_image.sh`


------
https://chatgpt.com/codex/tasks/task_e_687d52b81240832ca24dad404699595d