### PR TITLE
Split build and upload jobs

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -28,12 +28,18 @@ permissions:
 jobs:
   build:
     runs-on: self-hosted
+    outputs:
+      version: ${{ steps.set_vars.outputs.version }}
+      file_name: ${{ steps.set_vars.outputs.file_name }}
 
     steps:
       - name: Set build variables
+        id: set_vars
         run: |
           echo "VERSION=${{ github.event.inputs.version || github.ref_name }}" >> $GITHUB_ENV
           echo "FILE_NAME=${{ github.event.inputs.file_name || 'jammy-cloud-image-amd64' }}-${{ github.event.inputs.version || github.ref_name }}" >> $GITHUB_ENV
+          echo "version=${{ github.event.inputs.version || github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "file_name=${{ github.event.inputs.file_name || 'jammy-cloud-image-amd64' }}-${{ github.event.inputs.version || github.ref_name }}" >> $GITHUB_OUTPUT
 
       - name: Show build variables
         run: |
@@ -90,6 +96,27 @@ jobs:
             output/${{ env.FILE_NAME }}.img
             output/${{ env.FILE_NAME }}.img.sha256
 
+  release:
+    needs: build
+    runs-on: self-hosted
+
+    steps:
+      - name: Set upload variables
+        run: |
+          echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
+          echo "FILE_NAME=${{ needs.build.outputs.file_name }}" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact
+          path: output
+
       - name: Upload image to cloud repository
         id: upload_img
         env:
@@ -116,7 +143,6 @@ jobs:
           EOF
 
       - name: Create GitHub release
-        id: release_create
         run: |
           echo "Creating release for tag: ${{ env.VERSION }}"
           gh release create "${{ env.VERSION }}" \


### PR DESCRIPTION
## Summary
- split `build_release.yml` workflow into two jobs
- expose build metadata as job outputs
- add upload/release job that downloads the build artifact

## Testing
- `yamllint .github/workflows/build_release.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_687d565bc428832cae38bc6c9915b0e2