### PR TITLE
Fix provisioning scripts for node exporter and Ansible

### DIFF
--- a/script/ansible.sh
+++ b/script/ansible.sh
@@ -1,24 +1,24 @@
 #!/bin/bash -eu
 
-echo "$[INFO] Starting Ansible installation..."
-echo "$[INFO] Updating package lists..."
+echo "[INFO] Starting Ansible installation..."
+echo "[INFO] Updating package lists..."
 sudo apt-get update
 
-echo "$[INFO] Installing prerequisites..."
+echo "[INFO] Installing prerequisites..."
 sudo apt-get install -y software-properties-common
 
-echo "$[INFO] Adding Ansible PPA repository..."
+echo "[INFO] Adding Ansible PPA repository..."
 sudo add-apt-repository --yes --update ppa:ansible/ansible
 
-echo "$[INFO] Installing Ansible..."
+echo "[INFO] Installing Ansible..."
 sudo apt-get install -y ansible
 
-echo "$[INFO] Verifying Ansible installation..."
+echo "[INFO] Verifying Ansible installation..."
 if command -v ansible &> /dev/null; then
     ansible --version
-    echo "$[INFO] Ansible installed successfully!"
+    echo "[INFO] Ansible installed successfully!"
 else
-    echo "$[ERROR] Ansible installation failed."
+    echo "[ERROR] Ansible installation failed."
 fi
 
-echo "$[INFO] Ansible installation complete!"
+echo "[INFO] Ansible installation complete!"

--- a/script/node_exporter.sh
+++ b/script/node_exporter.sh
@@ -6,7 +6,6 @@ URL="https://github.com/prometheus/node_exporter/releases/download/${VERSION}/no
 INSTALL_DIR="/usr/local/bin"
 BINARY_NAME="node_exporter"
 SERVICE_FILE="/etc/systemd/system/node_exporter.service"
-TEMP_SERVICE_FILE="/tmp/node_exporter.service"
 
 echo "[INFO] Checking for wget..."
 if ! command -v wget &> /dev/null; then
@@ -16,10 +15,6 @@ fi
 echo "[INFO] Ensuring the node_exporter user exists..."
 if ! id "node_exporter" &>/dev/null; then
     sudo useradd --system --no-create-home --shell /usr/sbin/nologin node_exporter || echo "[ERROR] Failed to create node_exporter user."
-fi
-
-if ! command -v wget &> /dev/null; then
-    echo "[ERROR] wget is required but not installed. Please install it and run the script again."
 fi
 
 echo "[INFO] Downloading node_exporter from ${URL}..."
@@ -35,13 +30,21 @@ echo "[INFO] Setting permissions for node_exporter..."
 sudo chown node_exporter:node_exporter "${INSTALL_DIR}/${BINARY_NAME}" || echo "[ERROR] Failed to set ownership."
 sudo chmod 0755 "${INSTALL_DIR}/${BINARY_NAME}" || echo "[ERROR] Failed to set permissions."
 
-echo "[INFO] Copying service file to systemd directory..."
-if [ -f "${TEMP_SERVICE_FILE}" ]; then
-    sudo cp "${TEMP_SERVICE_FILE}" "${SERVICE_FILE}" || echo "[ERROR] Failed to copy service file to ${SERVICE_FILE}."
-    sudo chmod 644 "${SERVICE_FILE}" || echo "[ERROR] Failed to set permissions for the service file."
-else
-    echo "[ERROR] Service file ${TEMP_SERVICE_FILE} not found. Ensure the file exists and run the script again."
-fi
+echo "[INFO] Creating systemd service file..."
+sudo tee "${SERVICE_FILE}" > /dev/null <<'SERVICE'
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+ExecStart=/usr/local/bin/node_exporter
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+sudo chmod 644 "${SERVICE_FILE}" || echo "[ERROR] Failed to set permissions for the service file."
 
 echo "[INFO] Reloading systemd daemon..."
 sudo systemctl daemon-reload || echo "[ERROR] Failed to reload systemd daemon."
@@ -52,13 +55,10 @@ sudo systemctl start "${BINARY_NAME}" || echo "[ERROR] Failed to start node_expo
 
 echo "[INFO] Verifying node_exporter installation..."
 if systemctl is-active --quiet "${BINARY_NAME}"; then
-    
     echo "[INFO] node_exporter is running successfully!"
 else
-    
     echo "[INFO] Fetching node_exporter service logs..."
-    sudo journalctl -u "${BINARY_NAME}" --no-pager || 
-    echo "[INFO] No logs available for node_exporter service."
+    sudo journalctl -u "${BINARY_NAME}" --no-pager || echo "[INFO] No logs available for node_exporter service."
     echo "[ERROR] node_exporter failed to start."
 fi
 


### PR DESCRIPTION
## Summary
- embed Node Exporter systemd service creation in script
- correct Ansible installation log messages to avoid unbound variable

## Testing
- `shellcheck script/node_exporter.sh script/ansible.sh && echo shellcheck_ok`


------
https://chatgpt.com/codex/tasks/task_e_68a8f244e44c832c8dfd47c60ee16feb